### PR TITLE
Create fatjar instead of copying dependencies

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web:    java -cp target/classes:target/dependency/* Main
+web:    java -jar target/helloworld.jar

--- a/Procfile.windows
+++ b/Procfile.windows
@@ -1,1 +1,0 @@
-web:    java -cp target\classes;target\dependency\* Main

--- a/pom.xml
+++ b/pom.xml
@@ -31,25 +31,38 @@
   <build>
     <plugins>
       <plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-compiler-plugin</artifactId>
-    <version>2.5.1</version>
-    <configuration>
-        <source>1.8</source>
-        <target>1.8</target>
-        <optimize>true</optimize>
-        <debug>true</debug>
-    </configuration>
-</plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.4</version>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.5.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <optimize>true</optimize>
+          <debug>true</debug>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>2.3</version>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+          <finalName>helloworld</finalName>
+          <appendAssemblyId>false</appendAssemblyId>
+          <archive>
+            <manifest>
+              <mainClass>Main</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
         <executions>
           <execution>
-            <id>copy-dependencies</id>
+            <id>build-jar-with-dependencies</id>
             <phase>package</phase>
-            <goals><goal>copy-dependencies</goal></goals>
+            <goals>
+              <goal>single</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
This PR fixes a long standing problem on Windows where the `Procfile.windows` command would never work in all cases. Sometimes the args needed quoting, some times they didn't.

The new `Procfile` works perfectly on Mac, Linux and Windows. But we will need to update the tutorial to not mention `Procfile.windows` any more.