### PR TITLE
Use of JDBC_DATABASE_URL instead of DATABASE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Your app should now be running on [localhost:5000](http://localhost:5000/).
 If you're going to use a database, ensure you have a local `.env` file that reads something like this:
 
 ```
-DATABASE_URL=postgres://localhost:5432/java_database_name
+JDBC_DATABASE_URL=postgres://localhost:5432/java_database_name
 ```
 
 ## Deploying to Heroku


### PR DESCRIPTION
Use of JDBC_DATABASE_URL instead of DATABASE_URL which is only way to make this app work on local. https://pure-escarpment-94427.herokuapp.com/db is the deployed app on heroku which works too.