### PR TITLE
Upgrade to Spring-Boot 2.3.0

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "rundoc", github: "jkutner/rundoc", branch: "go-to-sleep-a-little-baby"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,0 +1,88 @@
+GIT
+  remote: https://github.com/jkutner/rundoc.git
+  revision: f18f1f39dcd0fd023b329f9af461fecfa98dfaa1
+  branch: go-to-sleep-a-little-baby
+  specs:
+    rundoc (1.1.0)
+      aws-sdk-s3 (~> 1)
+      capybara (~> 3)
+      dotenv
+      parslet (~> 1)
+      repl_runner
+      selenium-webdriver (~> 3)
+      thor
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (6.0.3.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    aws-eventstream (1.1.0)
+    aws-partitions (1.317.0)
+    aws-sdk-core (3.96.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.239.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.31.0)
+      aws-sdk-core (~> 3, >= 3.71.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.65.0)
+      aws-sdk-core (~> 3, >= 3.96.1)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.1.3)
+      aws-eventstream (~> 1.0, >= 1.0.2)
+    capybara (3.32.2)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
+    childprocess (3.0.0)
+    concurrent-ruby (1.1.6)
+    dotenv (2.7.5)
+    i18n (1.8.2)
+      concurrent-ruby (~> 1.0)
+    jmespath (1.4.0)
+    mini_mime (1.0.2)
+    mini_portile2 (2.4.0)
+    minitest (5.14.1)
+    nokogiri (1.10.9)
+      mini_portile2 (~> 2.4.0)
+    parslet (1.8.2)
+    public_suffix (4.0.5)
+    rack (2.2.2)
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
+    regexp_parser (1.7.0)
+    repl_runner (0.0.3)
+      activesupport
+    rubyzip (2.3.0)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
+    thor (1.0.1)
+    thread_safe (0.3.6)
+    tzinfo (1.2.7)
+      thread_safe (~> 0.1)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
+    zeitwerk (2.3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rundoc!
+
+BUNDLED WITH
+   2.1.2

--- a/docs/deploying-spring-boot-apps.md
+++ b/docs/deploying-spring-boot-apps.md
@@ -113,7 +113,7 @@ Now deploy your code:
 
 ```term
 :::>- $ git push heroku master
-:::-> | $ (head -6; echo "..."; tail -18)
+:::-> | (head -6; echo "..."; tail -18)
 ```
 
 Heroku automatically detects the application as a Maven/Java app due to the presence of a `pom.xml` file. It installed Java 8 by default, but you can easily configure this with a `system.properties` file as described in the [Specifying a Java version](https://devcenter.heroku.com/articles/java-support#specifying-a-java-version) Dev Center article. It will run your app using the [default command](https://devcenter.heroku.com/articles/java-support#default-web-process-type).

--- a/docs/java-getting-started.md
+++ b/docs/java-getting-started.md
@@ -265,7 +265,7 @@ Once dependencies are installed, you can run your app locally.
 Start your application locally with the `heroku local` CLI command (make sure you've already run `mvn clean install`):
 
 ```term
-:::>- background.start("heroku local web", name: "local1", wait: "Tomcat started", timeout: 30)
+:::>- background.start("heroku local web", name: "local1", wait: "Tomcat started", timeout: 75)
 :::-> | (echo "..."; tail -4)
 :::-- background.stop(name: "local1")
 ```
@@ -335,7 +335,7 @@ Now test your changes locally:
 ```term
 :::>- $ mvn clean install
 :::-> | (echo "..."; tail -7)
-:::>- background.start("heroku local web", name: "local2", wait: "Tomcat started", timeout: 30)
+:::>- background.start("heroku local web", name: "local2", wait: "Tomcat started", timeout: 75)
 :::-> | (echo "..."; tail -4)
 :::-- background.stop(name: "local2")
 ```
@@ -426,7 +426,7 @@ The `heroku run` command lets you run maintenance and administrative tasks on yo
 
 ```term
 :::>- $ heroku run java -version
-:::-> | $ tail -4
+:::-> | tail -4
 ```
 
 If you receive an error, `Error connecting to process`, then you might need to [configure your firewall](one-off-dynos#timeout-awaiting-process).

--- a/docs/java-getting-started.md
+++ b/docs/java-getting-started.md
@@ -127,7 +127,7 @@ First, create an app on Heroku, which prepares Heroku to receive your source cod
 :::>> $ heroku create
 ```
 
-When you create an app, a Git remote (named `heroku`) is also created and associated with your local Git repository.  
+When you create an app, a Git remote (named `heroku`) is also created and associated with your local Git repository.
 
 By default, Heroku generates a random name for your app. You can pass a parameter to specify your own app name.
 
@@ -135,7 +135,7 @@ Now deploy your code:
 
 ```term
 :::>- $ git push heroku master
-:::-> | $ (head -6; echo "..."; tail -18)
+:::-> | (head -6; echo "..."; tail -18)
 ```
 
 The application is now deployed. Ensure that at least one instance of the app is running:
@@ -236,7 +236,7 @@ Run `mvn clean install` in your local directory to install the dependencies, pre
 
 ```term
 :::>- $ mvn clean install
-:::-> | $ (echo "..."; tail -7)
+:::-> | (echo "..."; tail -7)
 ```
 
 If you do not have Maven installed, or get an error like `'mvn' is not recognized as an internal or external command`, then you can use the wrapper command instead by running `mvnw clean install` on Windows or `./mvnw clean install` on Mac and Linux. This both installs Maven and runs the Maven command.
@@ -266,7 +266,7 @@ Start your application locally with the `heroku local` CLI command (make sure yo
 
 ```term
 :::>- background.start("heroku local web", name: "local1", wait: "Tomcat started", timeout: 30)
-:::-> | $ (echo "..."; tail -4)
+:::-> | (echo "..."; tail -4)
 :::-- background.stop(name: "local1")
 ```
 
@@ -312,7 +312,7 @@ String hello(Map<String, Object> model) {
     model.put("science", "E=mc^2: 12 GeV = " + m.toString());
     return "hello";
 }
-```  
+```
 
 Finally, create a `src/main/resources/templates/hello.html` file with these contents:
 
@@ -334,9 +334,9 @@ Now test your changes locally:
 
 ```term
 :::>- $ mvn clean install
-:::-> | $ (echo "..."; tail -7)
+:::-> | (echo "..."; tail -7)
 :::>- background.start("heroku local web", name: "local2", wait: "Tomcat started", timeout: 30)
-:::-> | $ (echo "..."; tail -4)
+:::-> | (echo "..."; tail -4)
 :::-- background.stop(name: "local2")
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.1.6.RELEASE</version>
+    <version>2.3.0.RELEASE</version>
     <relativePath/>
   </parent>
   <name>java-getting-started</name>


### PR DESCRIPTION
This also includes updates to the rundoc templates. I had to use the master branch of https://github.com/schneems/rundoc to get them working for some reason.

In order to generate the rundoc yourself, you'll need to:

```
$ cd docs/
$ bundle install
$ bundle exec rundoc build --path java-getting-started.md
$ bundle exec rundoc build --path deploying-spring-boot-apps.md
```

Then the final docs will be in `java-getting-started/README.md` and `deploying-spring-boot-apps/README.md`.