### PR TITLE
Add database connection string default value

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,6 @@
 server.port=${PORT:5000}
-spring.datasource.url=${JDBC_DATABASE_URL}
+# Default to "jdbc:postgresql://example.com:5432/database" so that the application at least starts up when
+# JDBC_DATABASE_URL is not set. We use this here to reduce friction when newcomers work with this getting started
+# application. Production applications should not have a default like this, especially not ones that have credentials
+# in them!
+spring.datasource.url=${JDBC_DATABASE_URL:jdbc:postgresql://example.com:5432/database}


### PR DESCRIPTION
Currently, the getting started up does not even boot if no database connection string is configured. To reduce friction when working with this getting started app, a default connection string that points at `example.com` has been added. While this would still cause routes that need a database cause to fail, at least the application starts up successfully.

Ref: GUS-W-12680311