### PR TITLE
Reduce team review request noise from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,8 @@
+# Note: Delete this file if you are copying the code in this repository into your own project.
+
+# Default to requesting pull request reviews from the Heroku Languages team.
 * @heroku/languages
+
+# However, request review from the Heroku language owner for files that are updated
+# by Dependabot, to reduce team review request noise.
+pom.xml @Malax


### PR DESCRIPTION
The `CODEOWNERS` file has been adjusted to request review from the primary repository maintainer for high-traffic files that are typically updated via automation, rather than requesting review from the whole team.

For more information, see:
https://github.com/heroku/webapp-runner/pull/423

GUS-W-14941625.