### PR TITLE
Add viewport meta tag to HTML head

### DIFF
--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" th:fragment="layout (template, menu)" lang="en">
 <head>
     <title>Java Getting Started on Heroku</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/css/bootstrap.min.css"
           integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous"/>
     <link rel="stylesheet" type="text/css" href="/stylesheets/main.css"/>


### PR DESCRIPTION
Much better page dimensions and scaling on mobile devices; this tag is standard practice for HTML these days.

Also see https://github.com/heroku/php-getting-started/pull/74

GUS-W-16610879