### PR TITLE
Correct status code when migration is failing

### DIFF
--- a/src/main/java/com/heroku/java/GettingStartedApplication.java
+++ b/src/main/java/com/heroku/java/GettingStartedApplication.java
@@ -6,6 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
+import jakarta.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.util.ArrayList;
@@ -27,7 +28,7 @@ public class GettingStartedApplication {
     }
 
     @GetMapping("/database")
-    String database(Map<String, Object> model) {
+    String database(Map<String, Object> model, HttpServletResponse response) {
         try (Connection connection = dataSource.getConnection()) {
             final var statement = connection.createStatement();
             statement.executeUpdate("CREATE TABLE IF NOT EXISTS ticks (tick timestamp)");
@@ -42,8 +43,9 @@ public class GettingStartedApplication {
             model.put("records", output);
             return "database";
 
-        } catch (Throwable t) {
-            model.put("message", t.getMessage());
+        } catch (Exception e) {
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            model.put("message", e.getMessage());
             return "error";
         }
     }

--- a/src/main/java/com/heroku/java/GettingStartedApplication.java
+++ b/src/main/java/com/heroku/java/GettingStartedApplication.java
@@ -6,9 +6,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
-import jakarta.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
 import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Map;
 
@@ -28,7 +28,7 @@ public class GettingStartedApplication {
     }
 
     @GetMapping("/database")
-    String database(Map<String, Object> model, HttpServletResponse response) {
+    String database(Map<String, Object> model) throws SQLException {
         try (Connection connection = dataSource.getConnection()) {
             final var statement = connection.createStatement();
             statement.executeUpdate("CREATE TABLE IF NOT EXISTS ticks (tick timestamp)");
@@ -42,11 +42,6 @@ public class GettingStartedApplication {
 
             model.put("records", output);
             return "database";
-
-        } catch (Exception e) {
-            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-            model.put("message", e.getMessage());
-            return "error";
         }
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,4 @@ server.port=${PORT:5000}
 # application. Production applications should not have a default like this, especially not ones that have credentials
 # in them!
 spring.datasource.url=${JDBC_DATABASE_URL:jdbc:postgresql://example.com:5432/database}
+server.error.include-message=always


### PR DESCRIPTION
Currently, when the migration fails (possibly due to the database not being available yet) it returns a 200. This change fixes it to return a 500 to indicate a problem.

This is related to #238 but is not a full fix.